### PR TITLE
Fix Tailwind PostCSS configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "prettier": "^3.0.0",
     "tailwindcss": "^4.0.0",
     "postcss": "^8.4.0",
-    "autoprefixer": "^10.4.0",
-    "@tailwindcss/postcss": "^0.1.0"
+    "autoprefixer": "^10.4.0"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {}
   }
 }


### PR DESCRIPTION
## Summary
- drop reference to `@tailwindcss/postcss`
- configure PostCSS to use the `tailwindcss` plugin

## Testing
- `npm run lint` *(fails: next not found)*
- `npm install` *(fails: 403 Forbidden – registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_688193b08db0832892e0cc32acc34e11